### PR TITLE
ci: update Jenkinsfile to enable the manual uploading of SNAPSHOT artifacts

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,9 +9,9 @@ pipeline {
         }
     }
     environment {
-        JAVA_OPTS="-Dfile.encoding=UTF8"
-        LC_ALL="C.UTF-8"
-        jenkins_build="true"
+        JAVA_OPTS='-Dfile.encoding=UTF8'
+        LC_ALL='C.UTF-8'
+        jenkins_build='true'
     }
     parameters {
         booleanParam defaultValue: false, description: 'Whether to upload the SNAPSHOT artifact', name: 'SNAPSHOT'
@@ -24,15 +24,15 @@ pipeline {
         stage('Setup') {
             steps {
                 withCredentials([file(credentialsId: 'jenkins-maven-settings.xml', variable: 'SETTINGS_PATH')]) {
-                    sh "cp ${SETTINGS_PATH} settings-jenkins.xml"
+                    sh 'cp ${SETTINGS_PATH} settings-jenkins.xml'
                 }
             }
         }
         stage('Check SNAPSHOT version') {
             when {
                 allOf {
-                    expression { env.BRANCH_NAME != "release" }
-                    expression { env.BRANCH_NAME.contains("PR") }
+                    expression { env.BRANCH_NAME != 'release' }
+                    expression { env.BRANCH_NAME.contains('PR') }
                 }
             }
             steps {
@@ -42,7 +42,7 @@ pipeline {
                         returnStdout: true
                     ).trim()
 
-                    if (!projectVersion.contains("-SNAPSHOT")) {
+                    if (!projectVersion.contains('-SNAPSHOT')) {
                         currentBuild.result = 'ABORTED'
                         error('The current version of the project is not a SNAPSHOT')
                     }
@@ -58,8 +58,8 @@ pipeline {
             when {
                 allOf {
                     expression { params.SNAPSHOT == true }
-                    expression { env.BRANCH_NAME != "release" }
-                    expression { env.BRANCH_NAME.contains("PR") }
+                    expression { env.BRANCH_NAME != 'release' }
+                    expression { env.BRANCH_NAME.contains('PR') }
                 }
             }
             steps {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -44,7 +44,7 @@ pipeline {
 
                     if (!projectVersion.contains("-SNAPSHOT")) {
                         currentBuild.result = 'ABORTED'
-                        error('The current version of the project is not a SNAPSHOT ${projectVersion}')
+                        error('The current version of the project is not a SNAPSHOT')
                     }
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -31,6 +31,7 @@ pipeline {
                     expression { env.BRANCH_NAME != "release" }
                     expression { env.BRANCH_NAME.contains("PR") }
                 }
+            }
             steps {
                 def projectVersion = "mvn help:evaluate -Dexpression=project.version -q -DforceStdout"
                 if (!projectVersion.contains('-SNAPSHOT')) {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,6 +13,9 @@ pipeline {
         LC_ALL="C.UTF-8"
         jenkins_build="true"
     }
+    parameters {
+        booleanParam defaultValue: false, description: 'Whether to upload the SNAPSHOT artifact', name: 'SNAPSHOT'
+    }
     options {
         buildDiscarder(logRotator(numToKeepStr: '25'))
         timeout(time: 2, unit: 'HOURS')
@@ -33,16 +36,34 @@ pipeline {
                 }
             }
             steps {
-                def projectVersion = "mvn help:evaluate -Dexpression=project.version -q -DforceStdout"
-                if (!projectVersion.contains('-SNAPSHOT')) {
-                   currentBuild.result = 'ABORTED'
-                   error('The current version of the project is not a SNAPSHOT')
+                script {
+                    def projectVersion = sh (
+                        script: 'mvn help:evaluate -Dexpression=project.version -q -DforceStdout',
+                        returnStdout: true
+                    ).trim()
+
+                    if (!projectVersion.contains("-SNAPSHOT")) {
+                        currentBuild.result = 'ABORTED'
+                        error('The current version of the project is not a SNAPSHOT ${projectVersion}')
+                    }
                 }
             }
         }
         stage('Build') {
             steps {
                 sh 'mvn -B --settings settings-jenkins.xml package'
+            }
+        }
+        stage('Publish SNAPSHOT') {
+            when {
+                allOf {
+                    expression { params.SNAPSHOT == true }
+                    expression { env.BRANCH_NAME != "release" }
+                    expression { env.BRANCH_NAME.contains("PR") }
+                }
+            }
+            steps {
+                sh 'mvn -B --settings settings-jenkins.xml deploy'
             }
         }
         stage('Publish version') {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -25,6 +25,19 @@ pipeline {
                 }
             }
         }
+        stage('Check SNAPSHOT version') {
+            when {
+                allOf {
+                    expression { env.BRANCH_NAME != "release" }
+                    expression { env.BRANCH_NAME.contains("PR") }
+                }
+            steps {
+              def projectVersion = "mvn help:evaluate -Dexpression=project.version -q -DforceStdout"
+              if (!projectVersion.contains('-SNAPSHOT')) {
+                 currentBuild.result = 'ABORTED'
+                 error('The current version of the project is not a SNAPSHOT')
+            }
+        }
         stage('Build') {
             steps {
                 sh 'mvn -B --settings settings-jenkins.xml package'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,10 +32,11 @@ pipeline {
                     expression { env.BRANCH_NAME.contains("PR") }
                 }
             steps {
-              def projectVersion = "mvn help:evaluate -Dexpression=project.version -q -DforceStdout"
-              if (!projectVersion.contains('-SNAPSHOT')) {
-                 currentBuild.result = 'ABORTED'
-                 error('The current version of the project is not a SNAPSHOT')
+                def projectVersion = "mvn help:evaluate -Dexpression=project.version -q -DforceStdout"
+                if (!projectVersion.contains('-SNAPSHOT')) {
+                   currentBuild.result = 'ABORTED'
+                   error('The current version of the project is not a SNAPSHOT')
+                }
             }
         }
         stage('Build') {

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     <vavr.version>0.10.4</vavr.version>
   </properties>
 
-  <version>0.4.0</version>
+  <version>0.4.0-SNAPSHOT</version>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,6 @@ SPDX-License-Identifier: AGPL-3.0-only
     <vavr.version>0.10.4</vavr.version>
   </properties>
 
-  <version>0.4.0-SNAPSHOT</version>
+  <version>0.4.1-SNAPSHOT</version>
 
 </project>


### PR DESCRIPTION
In the Jenkinsfile:
- Added a stage to check if the project version has the SNAPSHOT label when the branch is on a PR and it is not `release`
- Added a stage to manual upload the SNAPSHOT artifact on artifactory via a checkbox

Refs: UM-32