### PR TITLE
fix(test): use containerized Docker Compose for CI compatibility

### DIFF
--- a/src/test/java/com/zextras/carbonio/usermanagement/support/DockerComposeExtension.java
+++ b/src/test/java/com/zextras/carbonio/usermanagement/support/DockerComposeExtension.java
@@ -4,6 +4,7 @@ import org.junit.jupiter.api.extension.AfterAllCallback;
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
 import org.testcontainers.containers.ComposeContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.io.File;
 import java.util.concurrent.TimeUnit;
@@ -14,7 +15,10 @@ public class DockerComposeExtension implements BeforeAllCallback, AfterAllCallba
 
     @Override
     public void beforeAll(final ExtensionContext context) throws Exception {
-        environment = new ComposeContainer(new File("docker/minimal/docker-compose.yaml"));
+        environment = new ComposeContainer(
+            DockerImageName.parse("docker:cli"),
+            new File("docker/minimal/docker-compose.yaml")
+        );
         environment.start();
         TimeUnit.SECONDS.sleep(30);
     }


### PR DESCRIPTION
Use DockerImageName parameter in ComposeContainer to run Docker Compose inside a container instead of relying on local docker CLI, which is not available in the Jenkins agent environment.