### PR TITLE
ci(jenkins): switch Prepare Release agent to sm-release-v1

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -118,7 +118,7 @@ pipeline {
         stage('Prepare Release') {
             agent {
                 node {
-                    label 'nodejs-v1'
+                    label 'sm-release-v1'
                 }
             }
             when {
@@ -135,7 +135,7 @@ pipeline {
             }
             steps {
                 script {
-                    container('nodejs-20') {
+                    container('nodejs-22') {
                         prepareRelease(
                             repoName: 'carbonio-user-management-sdk'
                         )


### PR DESCRIPTION
Fix pod parking deadlock by moving Prepare Release off nodejs-v1 to sm-release-v1.